### PR TITLE
chore(deps): bump github/codeql-action init/autobuild/analyze to 4.37.6

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,15 +33,15 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: ${{ matrix.language }}
           queries: security-extended,security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/autobuild@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
- Bumps `github/codeql-action/init`, `autobuild`, and `analyze` from **4.37.4 → 4.37.6** in one change.
- Replaces the three separate Dependabot PRs (#123, #124, #125), which failed CI because only one step was upgraded at a time (`Loaded a configuration file for version '4.37.6', but running version '4.37.4'`).

## Test plan
- [ ] CodeQL workflow passes on this PR
- [ ] Close superseded Dependabot PRs #123–125 after merge

Made with [Cursor](https://cursor.com)