### PR TITLE
fix(security): bump paramiko to 5.0.0 for CVE-2026-44405

### DIFF
--- a/netops-mcp-server/pyproject.toml
+++ b/netops-mcp-server/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "fastmcp>=3.4.6",
     "pyjwt>=2.12.0",  # GHSA: override transitive PyJWT (crit header); Dependabot alert #1
     "cryptography>=50.0.0",  # CVE-2026-69247 and prior crypto CVEs (transitive via paramiko / PyJWT)
+    "paramiko>=5.0.0",  # CVE-2026-44405 (transitive via netmiko)
     "python-multipart>=0.0.32",  # CVE-2026-40347 (transitive via Starlette/FastMCP)
     "starlette>=1.4.1",  # CVE-2026-54283, CVE-2026-48818 (transitive via FastMCP / sse-starlette)
     "mcp>=1.28.1",  # CVE-2026-59950, CVE-2026-52869/52870 (transitive via FastMCP)

--- a/netops-mcp-server/uv.lock
+++ b/netops-mcp-server/uv.lock
@@ -856,7 +856,7 @@ wheels = [
 
 [[package]]
 name = "netmiko"
-version = "4.7.0"
+version = "4.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ntc-templates" },
@@ -868,9 +868,9 @@ dependencies = [
     { name = "scp" },
     { name = "textfsm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/87/f7/28dc70a15f496635a9353726e7015d4819ed648a06f57f4b362176a57d51/netmiko-4.7.0.tar.gz", hash = "sha256:94cf7bfe5daed1d058444ce1637e10177df22f903683a53d1fbee47553488c65", size = 185674, upload-time = "2026-05-12T18:26:14.39Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/0a/4d557ffd4070a47f87c3e07abd28f9fcbdbf799f2a62940168236b4a8d31/netmiko-4.6.0.tar.gz", hash = "sha256:9701bb2c1a15eb2e8074cb2e28ca007c69b9fa52961b83b98c757ead6b80deef", size = 169274, upload-time = "2025-06-26T19:13:17.303Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/6d/7464ecd76316b40b875fd8a8e3128871dc8d24183cfb42b8f76527d8662d/netmiko-4.7.0-py3-none-any.whl", hash = "sha256:406684e45b3822e17efa0f8e376644995693ff40a750c297ccce0c58e873f29d", size = 294307, upload-time = "2026-05-12T18:26:12.73Z" },
+    { url = "https://files.pythonhosted.org/packages/32/5b/9db3cf51785ef0a50f0976704e0776e7136a83cbdf9ed84065184f1fe3e2/netmiko-4.6.0-py3-none-any.whl", hash = "sha256:0c9b7309005d2c8a010b275f3494628cadb1658a8841632131c848074b7cdadb", size = 262873, upload-time = "2025-06-26T19:13:15.764Z" },
 ]
 
 [[package]]
@@ -883,6 +883,7 @@ dependencies = [
     { name = "httpx" },
     { name = "mcp" },
     { name = "netmiko" },
+    { name = "paramiko" },
     { name = "pydantic-settings" },
     { name = "pygments" },
     { name = "pyjwt" },
@@ -905,6 +906,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.24" },
     { name = "mcp", specifier = ">=1.28.1" },
     { name = "netmiko", specifier = ">=4.0" },
+    { name = "paramiko", specifier = ">=5.0.0" },
     { name = "pydantic-settings", specifier = ">=2.15.0" },
     { name = "pygments", specifier = ">=2.20.0" },
     { name = "pyjwt", specifier = ">=2.12.0" },
@@ -965,7 +967,7 @@ wheels = [
 
 [[package]]
 name = "paramiko"
-version = "4.0.0"
+version = "5.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "bcrypt" },
@@ -973,9 +975,9 @@ dependencies = [
     { name = "invoke" },
     { name = "pynacl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/e7/81fdcbc7f190cdb058cffc9431587eb289833bdd633e2002455ca9bb13d4/paramiko-4.0.0.tar.gz", hash = "sha256:6a25f07b380cc9c9a88d2b920ad37167ac4667f8d9886ccebd8f90f654b5d69f", size = 1630743, upload-time = "2025-08-04T01:02:03.711Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/93/dcc25d52f49022ae6175d15e6bd751f1acc99b98bc61fc55e5155a7be2e7/paramiko-5.0.0.tar.gz", hash = "sha256:36763b5b95c2a0dcfdf1abc48e48156ee425b21efe2f0e787c2dd5a95c0e5e79", size = 1548586, upload-time = "2026-05-09T18:28:52.256Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/90/a744336f5af32c433bd09af7854599682a383b37cfd78f7de263de6ad6cb/paramiko-4.0.0-py3-none-any.whl", hash = "sha256:0e20e00ac666503bf0b4eda3b6d833465a2b7aff2e2b3d79a8bba5ef144ee3b9", size = 223932, upload-time = "2025-08-04T01:02:02.029Z" },
+    { url = "https://files.pythonhosted.org/packages/82/5b/eadf6d45de38d30ab603f49393b6cd2cbe7e233af8cf90197e32782b68a9/paramiko-5.0.0-py3-none-any.whl", hash = "sha256:b7044611c30140d9a75261653210e2002977b71a0497ff3ba0d98d7edbf62f7c", size = 208919, upload-time = "2026-05-09T18:28:50.295Z" },
 ]
 
 [[package]]
@@ -1629,8 +1631,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
## Summary
- Pins `paramiko>=5.0.0` in `netops-mcp-server` to fix **CVE-2026-44405** (SHA-1 allowed in RSA key handling through paramiko 4.0.0).
- Resolves Dependabot alert #15.
- `netmiko` resolves to 4.6.0 (4.7.0 caps paramiko at `<5.0`).

## Test plan
- [x] `uv lock` resolves paramiko 5.0.0
- [ ] CodeQL passes on PR

Made with [Cursor](https://cursor.com)